### PR TITLE
🚑️ Forward client routing in production

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -1,10 +1,16 @@
 import express from 'express';
+import path from 'path';
 
 const { PORT = 3000 } = process.env;
 const app = express();
 
 // Serve app production bundle
 app.use(express.static('dist/app'));
+
+// Handle client routing, return all requests to the app
+app.get('*', (_req, res) => {
+  res.sendFile(path.join(__dirname, 'app/index.html'));
+});
 
 // Serve storybook production bundle
 app.use('/storybook', express.static('dist/storybook'));


### PR DESCRIPTION
On production (Heroku deployment or npm start), it's not possible to directly go to routes like /register.
This pull request fixes this issue and forwards all routes to the client.